### PR TITLE
[2-parsers] Add virtual destructors for Function and Operator

### DIFF
--- a/2-parsers/include/ast/ast_functions.hpp
+++ b/2-parsers/include/ast/ast_functions.hpp
@@ -15,6 +15,11 @@ protected:
         : arg(_arg)
     {}
 public:
+    virtual ~Function()
+    {
+        delete arg;
+    }
+
     virtual const char * getFunction() const =0;
 
     ExpressionPtr getArg() const

--- a/2-parsers/include/ast/ast_operators.hpp
+++ b/2-parsers/include/ast/ast_operators.hpp
@@ -16,6 +16,12 @@ protected:
         , right(_right)
     {}
 public:
+    virtual ~Operator()
+    {
+        delete left;
+        delete right;
+    }
+
     virtual const char *getOpcode() const =0;
 
     ExpressionPtr getLeft() const


### PR DESCRIPTION
I believe that the destructors are needed to clean up the expressions that were allocated in the parser.

It is also described in the [readme](https://github.com/LangProc/langproc-2019-lab/tree/master/2-parsers) in the last paragraph of the first section.