### PR TITLE
[2-parsers] Make the member variables in AST private

### DIFF
--- a/2-parsers/include/ast/ast_operators.hpp
+++ b/2-parsers/include/ast/ast_operators.hpp
@@ -7,10 +7,10 @@
 class Operator
     : public Expression
 {
-protected:
+private:
     ExpressionPtr left;
     ExpressionPtr right;
-
+protected:
     Operator(ExpressionPtr _left, ExpressionPtr _right)
         : left(_left)
         , right(_right)
@@ -58,8 +58,8 @@ public:
     ) const override 
     {
         // TODO-C : Run bin/eval_expr with something like 5+a, where a=10, to make sure you understand how this works
-        double vl=left->evaluate(bindings);
-        double vr=right->evaluate(bindings);
+        double vl=getLeft()->evaluate(bindings);
+        double vr=getRight()->evaluate(bindings);
         return vl+vr;
     }
 };

--- a/2-parsers/include/ast/ast_unary.hpp
+++ b/2-parsers/include/ast/ast_unary.hpp
@@ -7,9 +7,9 @@
 class Unary
     : public Expression
 {
-protected:
+private:
     ExpressionPtr expr;
-
+protected:
     Unary(const ExpressionPtr _expr)
         : expr(_expr)
     {}


### PR DESCRIPTION
Make the member variables private in Operator and Unary as per the
documentation to promote the const nature of the AST. These can then not
be modified and changes to the tree can only be done by constructing a
new tree.